### PR TITLE
refactor: use kit instead of ethers

### DIFF
--- a/packages/react-app/pages/_app.tsx
+++ b/packages/react-app/pages/_app.tsx
@@ -1,9 +1,7 @@
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
-import { CeloProvider, Alfajores } from '@celo/react-celo';
-import '@celo/react-celo/lib/styles.css';
-
-
+import { CeloProvider, Alfajores } from "@celo/react-celo";
+import "@celo/react-celo/lib/styles.css";
 
 import Layout from "../components/Layout";
 import { ShoppingCartProvider } from "@/context/ShoppingCartContext";
@@ -23,13 +21,13 @@ function App({ Component, pageProps }: AppProps) {
         providersOptions: { searchable: true },
       }}
     >
-      <MarketPlaceProvider>
-        <ShoppingCartProvider>
+      <ShoppingCartProvider>
+        <MarketPlaceProvider>
           <Layout>
             <Component {...pageProps} />
           </Layout>
-        </ShoppingCartProvider>
-      </MarketPlaceProvider>
+        </MarketPlaceProvider>
+      </ShoppingCartProvider>
     </CeloProvider>
   );
 }


### PR DESCRIPTION
Hello MartianEddy

I have viewed your project and made some necessary changes on the frontend.

**Fixes and Improvements**

1. Replaced Ethers library to Kit from `useCelo` hook from `react-celo` hook. This will enable users to use any wallet of their choice while signing transactions instead of using only metamask.

2. Changed `handleClick` function to ensure users are charged based on cart items price instead of the price of one selected items.